### PR TITLE
feat:初步优化前端渲染,打入WASM接口

### DIFF
--- a/.github/workflows/tauri-publish.yml
+++ b/.github/workflows/tauri-publish.yml
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: install frontend dependencies
-        run: pnpm install # change this to npm, pnpm or bun depending on which one you use.
+        run: pnpm install --frozen-lockfile
 
       - uses: tauri-apps/tauri-action@v0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ coverage
 *.tsbuildinfo
 
 # dist zip file
-dist.zip
+dist.zip!/
+perf-reports/

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>要石 v2.6.0</title>
+    <title>要石 v2.7.0</title>
   </head>
   <body>
     <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "kanameishi",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "build:profile": "vite build --sourcemap",
+    "preview": "vite preview",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,7 +92,7 @@ pub fn run() {
             let _ = TrayIconBuilder::new()
                 .menu(&menu)
                 .icon(icon)
-                .tooltip("要石 v2.6.0")
+                .tooltip("要石 v2.7.0")
                 .on_menu_event(move |tray, event| match event.id().as_ref() {
                     TRAY_SHOW_WINDOW_ID => {
                         show_main_window(tray.app_handle());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "kanameishi",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "identifier": "com.viewer.wolfx",
   "build": {
     "frontendDist": "../dist",
@@ -13,7 +13,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "要石 kanameishi v2.6.0",
+        "title": "要石 kanameishi v2.7.0",
         "width": 1280,
         "height": 720,
         "minWidth": 640,

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@ import { platform } from '@tauri-apps/plugin-os';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import Http from './classes/Http';
+import { warmTopojsonCache } from './utils/TopojsonCache';
 
 const timeStore = useTimeStore()
 const statusStore = useStatusStore()
@@ -42,12 +43,7 @@ async function syncTrayGameModeMenu(enabled) {
 async function getGeojson(retries = 0){
   if(!inTauri && ('caches' in window)){
     try {
-      const promises = Object.keys(topojsonUrls).map(async name => {
-        const data = await Http.get(topojsonUrls[name], { timeout: 0 })
-        const cache = await caches.open('topojson')
-        await cache.put(topojsonUrls[name], new Response(JSON.stringify(data)))
-      })
-      await Promise.all(promises)
+      await warmTopojsonCache(topojsonUrls, url => Http.get(url, { timeout: 0 }))
     } catch (err) {
       console.log(err);
       if(retries < 3) {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -3,18 +3,21 @@
   src: url('./fonts/HarmonyOS_Sans_Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'HMOS Sans SC';
   src: url('./fonts/HarmonyOS_SansSC_Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: 'HMOS Sans TC';
   src: url('./fonts/HarmonyOS_SansTC_Regular.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 *{

--- a/src/components/EqlistComponent.vue
+++ b/src/components/EqlistComponent.vue
@@ -39,7 +39,7 @@
               </span>
             </template>
             <el-option label="CENC" value="CENC" :disabled="!statusStore.enabledSource.includes('cencEqlist')" />
-            <el-option label="CWA" value="CWA" v-if="settingsStore.advancedSettings.enableTremFunctions" :disabled="!statusStore.enabledSource.includes('cwaEqlist')" />
+            <el-option label="CWA" value="CWA" :disabled="!statusStore.enabledSource.includes('cwaEqlist')" />
             <el-option label="JMA" value="JMA" :disabled="!statusStore.enabledSource.includes('jmaEqlist')" />
             <el-option label="USGS" value="USGS" :disabled="!statusStore.enabledSource.includes('usgsEqlist')" />
             <el-option label="FSSN" value="FSSN" :disabled="!statusStore.enabledSource.includes('fssnEqlist')" />

--- a/src/components/MainMapComponent.vue
+++ b/src/components/MainMapComponent.vue
@@ -356,8 +356,9 @@ import { useSettingsStore } from '@/stores/settings';
 import { useTimeStore } from '@/stores/time';
 import EqlistComponent from './EqlistComponent.vue';
 import SettingsComponent from './SettingsComponent.vue';
-import { verifyUpToDate, setClassName, getClassLevel, classNameArray, pointDistToCnArea, pointDistToKrArea, csisArray, shindoArray, calcCsisLevel, calcJmaShindoLevel, formatTimeZone, simplifyTopoJson, formatCsis, csisRomanArray, formatShindo } from '@/utils/Utils';
+import { verifyUpToDate, setClassName, getClassLevel, classNameArray, csisArray, shindoArray, calcCsisLevel, calcJmaShindoLevel, formatTimeZone, simplifyTopoJson, formatCsis, csisRomanArray, formatShindo } from '@/utils/Utils';
 import { topojsonUrls } from '@/utils/Urls';
+import { loadTopojsonResources } from '@/utils/TopojsonCache';
 import { jmaSeisIntLoc } from '@/utils/JmaSeisIntLoc';
 import { isTauri } from '@tauri-apps/api/core';
 import { storeToRefs } from 'pinia';
@@ -653,12 +654,7 @@ onMounted(()=>{
         map.on('zoomstart', ()=>{setMapHeight('calc(100% - 1px)');})
         map.on('zoomend', ()=>{setMapHeight('100%');})
     }
-    document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible' && pendingSetView) {
-            pendingSetView = false
-            setView(true)
-        }
-    })
+    document.addEventListener('visibilitychange', handleVisibilityChange)
     watchEffect(()=>{
         if(userMarker && map.hasLayer(userMarker)) map.removeLayer(userMarker)
         if(isDisplayUser.value){
@@ -876,15 +872,14 @@ const loadMaps = async (retries = 0) => {
             firstMsg = true
         }, 1000);
     }
-    let promises, shouldRetry = false
-    if(!isTauri() && ('caches' in window)){
-        const cache = await caches.open('topojson')
-        promises = Object.keys(topojsonUrls).map(key=>cache.match(topojsonUrls[key]).then(res=>res?.json()))
+    let shouldRetry = false
+    let resps = []
+    try {
+        resps = await loadTopojsonResources(topojsonUrls, !isTauri())
+    } catch (err) {
+        console.log(err)
+        shouldRetry = true
     }
-    else{
-        promises = Object.keys(topojsonUrls).map(key=>fetch(topojsonUrls[key]).then(res=>res?.json()))
-    }
-    const resps = await Promise.all(promises)
     const [global, cn, cn_eew, cn_fault, jp, jp_eew, jp_tsunami, kr_eew, cn_tsunami] = resps
     if(global && cn && cn_eew && cn_fault && jp && jp_eew && kr_eew && jp_tsunami){
         clearTimeout(msgTimer)
@@ -995,6 +990,7 @@ const loadMaps = async (retries = 0) => {
             })
         }, { deep: true, immediate: true })
         if(settingsStore.advancedSettings.forceCalcInt){
+            const { pointDistToCnArea, pointDistToKrArea } = await import('@/utils/AreaDistance')
             watch(eewInfoList, newVal=>{
                 const newCsisList = {}
                 const cnAreaClass = {}, krAreaClass = {}
@@ -1149,6 +1145,12 @@ const setMapHeight = (height) => {
     }, 0);
 }
 let pendingSetView = false
+const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible' && pendingSetView) {
+        pendingSetView = false
+        setView(true)
+    }
+}
 let largeZoomingTimer
 const setView = (force = false) => {
     if(!map) return
@@ -1591,6 +1593,7 @@ onBeforeUnmount(()=>{
     clearTimeout(defaultMenuTimer)
     clearTimeout(tempEqlistsTimer)
     clearTimeout(largeZoomingTimer)
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
     document.removeEventListener('mousemove', resetDefaultMenuTimer)
     document.removeEventListener('keydown', handleKeydown)
     activeEewList.length = 0

--- a/src/components/SettingsComponent.vue
+++ b/src/components/SettingsComponent.vue
@@ -1277,7 +1277,7 @@
             </template>
         </el-dialog>
         <el-dialog class="about-box" v-model="showAbout" width="60%" :show-close="false" append-to-body>
-            <div class="header">要石 v2.6.0</div>
+            <div class="header">要石 v2.7.0</div>
             <div class="title">注意事项</div>
             <div class="about">
                 <p>本应用程序仅作为学习使用。</p>

--- a/src/components/components/KmaNet.vue
+++ b/src/components/components/KmaNet.vue
@@ -31,6 +31,12 @@ let distMatrix = [[]]
 let adjStationIds = {}
 let map
 let pendingRender = false
+const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible' && pendingRender) {
+        pendingRender = false
+        renderAll()
+    }
+}
 let decimal = [0, 0]
 const gridRects = {}
 const activeStations = computed(()=>{
@@ -167,12 +173,7 @@ onMounted(()=>{
             }
         }
     })
-    document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible' && pendingRender) {
-            pendingRender = false
-            renderAll()
-        }
-    })
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 })
 let unwatchGrids, unwatchStationList, unwatchRender
 watch(()=>statusStore.map, newVal=>{
@@ -322,6 +323,7 @@ watch(currentMaxShindo, (newVal, oldVal)=>{
 })
 onBeforeUnmount(()=>{
     kmaSocket?.close()
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
     if(map !== null) map.off('zoomend', renderAll)
     if(unwatchGrids) unwatchGrids()
     if(unwatchStationList) unwatchStationList()

--- a/src/components/components/MockEew.vue
+++ b/src/components/components/MockEew.vue
@@ -118,7 +118,8 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import { getFEName } from '@/utils/FERegions';
 import { Plus } from '@element-plus/icons-vue';
-import { calcCsisLevel, calcMaxJmaShindoLevel } from '@/utils/Utils';
+import { calcCsisLevel } from '@/utils/Utils';
+import { calcMaxJmaShindoLevel } from '@/utils/JmaMaxIntensity';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 

--- a/src/components/components/NiedNet.vue
+++ b/src/components/components/NiedNet.vue
@@ -88,6 +88,12 @@ const getData = async (url)=>{
     }
 }
 let pendingRender = false
+const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible' && pendingRender) {
+        pendingRender = false
+        renderAll()
+    }
+}
 const nearbyLength = 6
 const activityThresArr = [Infinity, 9, 12, 14, 15, 16, 16]
 const update = ()=>{
@@ -313,12 +319,7 @@ onMounted(()=>{
             console.log(err);
         }
     }, 500);
-    document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible' && pendingRender) {
-            pendingRender = false
-            renderAll()
-        }
-    })
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 })
 let unwatchGrids, unwatchRender
 watch(()=>statusStore.map, newVal=>{
@@ -444,6 +445,7 @@ onBeforeUnmount(()=>{
     clearInterval(fetchStationInterval)
     clearInterval(requestInterval)
     clearInterval(delayInterval)
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
     if(map !== null) map.off('zoomend', renderAll)
     if(unwatchGrids) unwatchGrids()
     if(unwatchRender) unwatchRender()

--- a/src/components/components/TremNet.vue
+++ b/src/components/components/TremNet.vue
@@ -73,6 +73,12 @@ const grids = computed(()=>{
     return grids
 })
 let pendingRender = false
+const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible' && pendingRender) {
+        pendingRender = false
+        renderAll()
+    }
+}
 const update = ()=>{
     const render = document.visibilityState === 'visible'
     if(!render) pendingRender = true
@@ -133,12 +139,7 @@ onMounted(()=>{
             console.log(err);
         }
     }, 1000);
-    document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'visible' && pendingRender) {
-            pendingRender = false
-            renderAll()
-        }
-    })
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 })
 let unwatchStationList, unwatchGrids, unwatchRender
 watch(()=>statusStore.map, newVal=>{
@@ -270,6 +271,7 @@ const stationDataUrl = computed(() => delay.value > 0 ? seisNetUrls?.trem.statio
 onBeforeUnmount(()=>{
     clearInterval(fetchStationInterval)
     clearInterval(requestInterval)
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
     if(map !== null) map.off('zoomend', renderAll)
     if(unwatchStationList) unwatchStationList()
     if(unwatchGrids) unwatchGrids()

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import merge from 'lodash/merge';
-import { point, distance } from '@turf/turf';
 import { jmaSeisIntLoc } from '@/utils/JmaSeisIntLoc';
+import { calcSurfaceDistanceKm } from '@/utils/SeismicCalculations';
 
 export const useSettingsStore = defineStore('settingsStore', {
     state: ()=>({
@@ -148,14 +148,12 @@ export const useSettingsStore = defineStore('settingsStore', {
         nearestJmaLoc(state) {
             if(this.isValidUserLatLng) {
                 const userCoord = [state.mainSettings.userLatLng[1], state.mainSettings.userLatLng[0]]
-                const userPoint = point(userCoord)
                 let nearestLoc = null
                 let nearestDist = 30
                 for(let loc in jmaSeisIntLoc) {
                     const locCoord = [jmaSeisIntLoc[loc].location[1], jmaSeisIntLoc[loc].location[0]]
                     if(Math.abs(userCoord[0] - locCoord[0]) >= 0.39 || Math.abs(userCoord[1] - locCoord[1]) >= 0.27) continue
-                    const locPoint = point(locCoord)
-                    const dist = distance(userPoint, locPoint, { units: 'kilometers' })
+                    const dist = calcSurfaceDistanceKm(userCoord[1], userCoord[0], locCoord[1], locCoord[0])
                     if(dist < nearestDist) {
                         nearestDist = dist
                         nearestLoc = jmaSeisIntLoc[loc]

--- a/src/stores/status.js
+++ b/src/stores/status.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import Http from '@/classes/Http';
 import WebSocketObj from '@/classes/WebSocket';
 import { eqUrls, iconUrls, tsunamiUrls } from '@/utils/Urls';
-import { setClassName, calcCsisLevel, stampToTime, getShindoFromInstShindo, shindoScaleKanji, calcTimeDiff, shindoScale, playSound, sendMyNotification, focusWindow } from '@/utils/Utils';
+import { setClassName, calcCsisLevel, stampToTime, getShindoFromInstShindo, shindoScaleKanji, calcTimeDiff, playSound, sendMyNotification, focusWindow, formatShindo } from '@/utils/Utils';
 import { jmaSeisIntLoc } from '@/utils/JmaSeisIntLoc';
 import { useSettingsStore } from './settings';
 import { isTauri } from '@tauri-apps/api/core';
@@ -425,7 +425,7 @@ export const useStatusStore = defineStore('statusStore', {
                                 eqMessage.originTimeText = '時間: ' + eqMessage.originTime
                                 eqMessage.magnitude = data.magnitude
                                 eqMessage.magnitudeText = '規模: ' + eqMessage.magnitude.toFixed(1)
-                                eqMessage.maxIntensity = data.maxIntensity?.replace('級', '') || '不明'
+                                eqMessage.maxIntensity = formatShindo(data.maxIntensity, false) || '不明'
                                 eqMessage.maxIntensityText = '預估最大震度: ' + eqMessage.maxIntensity
                                 eqMessage.isWarn = eqMessage.maxIntensity >= '5' && eqMessage.maxIntensity != '不明'
                                 break
@@ -1162,22 +1162,24 @@ export const useStatusStore = defineStore('statusStore', {
                         break
                     }
                     case 'cwaEqlist': {
-                        const locStart = data[i].loc.indexOf('(位於')
-                        const locEnd = data[i].loc.indexOf(')')
-                        const hypocenter = locStart == -1 || locEnd == -1 || locStart + 3 >= locEnd ? data[i].loc : data[i].loc.slice(locStart + 3, locEnd)
+                        const placeName = data[i].placeName
+                        const locStart = placeName.indexOf('(位於')
+                        const locEnd = placeName.indexOf(')')
+                        const hypocenter = locStart == -1 || locEnd == -1 || locStart + 3 >= locEnd ? placeName : placeName.slice(locStart + 3, locEnd)
+                        const maxIntensity = formatShindo(data[i].maxIntensity)
                         list[i] = {
                             source: 'CWA',
                             id: data[i].id,
                             timeZone: 8,
                             useShindo: true,
-                            originTime: stampToTime(data[i].time, 8),
-                            lat: data[i].lat,
-                            lng: data[i].lon,
+                            originTime: data[i].shockTime,
+                            lat: data[i].latitude,
+                            lng: data[i].longitude,
                             hypocenter,
                             depth: data[i].depth,
-                            magnitude: data[i].mag,
-                            maxIntensity: shindoScale[data[i].int],
-                            className: setClassName(shindoScale[data[i].int], true),
+                            magnitude: data[i].magnitude,
+                            maxIntensity,
+                            className: setClassName(maxIntensity, true),
                             url: 'https://scweb.cwa.gov.tw/zh-tw/earthquake/data'
                         }
                         break
@@ -1289,11 +1291,10 @@ export const useStatusStore = defineStore('statusStore', {
                             const data = await Http.get(tsunamiUrls.jmaTsunami_http)
                             if(data && data.length > 0) this.setTsunamiMessage(source, data[0])
                         }
-                        if(source == 'cwaEqlist' && 'cwaEqlist_http' in eqUrls && status % 2 == 0) {
+                        if(source == 'cwaEqlist' && 'cwaEqlist_http' in eqUrls) {
                             const data = await Http.get(eqUrls.cwaEqlist_http + `&time=${stamp}`)
                             if(data && data.length > 0) {
                                 this.setEqMessage(source, data[0])
-                                this.setHistory(source, data)
                             }
                         }
                         if(source == 'usgsEqlist' && status % 10 == 0) {
@@ -1352,6 +1353,10 @@ export const useStatusStore = defineStore('statusStore', {
                     const token = settingsStore.advancedSettings.tokens.fan_dev
                     if(token) initMsg.push(`{"type":"auth","key":"${token}"}`)
                     const autoMsg = ['query']
+                    if(this.activeFanSources.includes('cwaEqlist')) {
+                        autoMsg.push('cwalist')
+                        initMsg.push('cwalist')
+                    }
                     if(this.activeFanSources.includes('cencEqlist')) {
                         autoMsg.push('cencirlist', 'cenclist')
                         initMsg.push('cencirlist', 'cenclist')
@@ -1380,6 +1385,12 @@ export const useStatusStore = defineStore('statusStore', {
                                 const Data = data?.Data
                                 if(source && this.activeFanSources.includes(source) && Data)
                                     source.endsWith('Tsunami') ? this.setTsunamiMessage(source, Data) : this.setEqMessage(source, Data, 1)
+                                break
+                            }
+                            case 'cwalist_response': {
+                                const source = 'cwaEqlist'
+                                const Data = data?.Data
+                                this.setHistory(source, Data)
                                 break
                             }
                             case 'cenclist_response': {

--- a/src/utils/AreaDistance.js
+++ b/src/utils/AreaDistance.js
@@ -1,0 +1,27 @@
+import { booleanPointInPolygon, point, distance } from "@turf/turf";
+import { around } from "geokdbush";
+import { cnSeisIntLoc, cnSeisIntLocBush } from "./CnSeisIntLoc";
+import { krSeisIntLoc, krSeisIntLocBush } from "./KrSeisIntLoc";
+
+const pointDistToArea = (pointLngLat, feature, locs, bushes) => {
+  const turfPoint = point(pointLngLat);
+  if (booleanPointInPolygon(turfPoint, feature)) {
+    return 0;
+  }
+
+  const name = feature.properties.name;
+  const kdbush = bushes[name];
+  const nearestPoint = around(kdbush, pointLngLat[0], pointLngLat[1], 1).map(
+    index => locs[name][index],
+  )[0];
+
+  return distance(turfPoint, point(nearestPoint), {
+    units: "kilometers",
+  });
+};
+
+export const pointDistToCnArea = (pointLngLat, feature) =>
+  pointDistToArea(pointLngLat, feature, cnSeisIntLoc, cnSeisIntLocBush);
+
+export const pointDistToKrArea = (pointLngLat, feature) =>
+  pointDistToArea(pointLngLat, feature, krSeisIntLoc, krSeisIntLocBush);

--- a/src/utils/JmaMaxIntensity.js
+++ b/src/utils/JmaMaxIntensity.js
@@ -1,0 +1,23 @@
+import { jmaSeisIntLoc } from "./JmaSeisIntLoc";
+import { calcJmaShindo, getShindoFromInstShindo } from "./SeismicCalculations";
+
+export const calcMaxJmaShindoLevel = (
+  mj,
+  dep,
+  hypoLat,
+  hypoLng,
+  useSymbol = true,
+) => {
+  const locList = Object.keys(jmaSeisIntLoc);
+  const maxInt = locList.reduce(
+    (maxInt, currLoc) =>
+      Math.max(
+        calcJmaShindo(mj, dep, hypoLat, hypoLng, jmaSeisIntLoc[currLoc]),
+        maxInt,
+      ),
+    -Infinity,
+  );
+  const maxInt1 = Math.floor(Math.round(maxInt * 100) / 10) / 10;
+  if (maxInt1 < 0.5) return "0";
+  else return getShindoFromInstShindo(maxInt1, useSymbol);
+};

--- a/src/utils/SeismicCalculations.js
+++ b/src/utils/SeismicCalculations.js
@@ -1,0 +1,151 @@
+const EARTH_RADIUS_KM = 6371;
+
+const toRadians = value => (Number(value) * Math.PI) / 180;
+
+export const calcSurfaceDistanceKm = (lat1, lng1, lat2, lng2) => {
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+  const rLat1 = toRadians(lat1);
+  const rLat2 = toRadians(lat2);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(rLat1) * Math.cos(rLat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+};
+
+export const calcWaveDistance = (travelTime, isPWave, depth, time) => {
+  if (depth < 0) depth = 0;
+  if (time < 0) time = 0;
+  const { depths, distances, p_times, s_times } = travelTime;
+  const data = isPWave ? p_times : s_times;
+  let i = 1;
+  while (depths[i] < depth && i < depths.length - 1) i++;
+  const k1 = depths[i] - depth;
+  const k2 = depth - depths[i - 1];
+  const times = [];
+  for (let j = 0; j < distances.length; j++) {
+    times[j] = (k1 * data[i - 1][j] + k2 * data[i][j]) / (k1 + k2);
+  }
+  if (time <= times[0]) return { reach: time / times[0], radius: 0 };
+  let j = 1;
+  while (times[j] < time && j < times.length - 1) j++;
+  const k = (distances[j] - distances[j - 1]) / (times[j] - times[j - 1]);
+  const b = distances[j] - k * times[j];
+  const distance = k * time + b;
+  return { reach: 1, radius: distance };
+};
+
+export const calcReachTime = (travelTime, isPWave, depth, distance) => {
+  if (depth < 0) depth = 0;
+  if (distance < 0) distance = 0;
+  const { depths, distances, p_times, s_times } = travelTime;
+  const data = isPWave ? p_times : s_times;
+  let i = 1;
+  while (depths[i] < depth && i < depths.length - 1) i++;
+  const k1 = depths[i] - depth;
+  const k2 = depth - depths[i - 1];
+  const times = [];
+  for (let j = 0; j < distances.length; j++) {
+    times[j] = (k1 * data[i - 1][j] + k2 * data[i][j]) / (k1 + k2);
+  }
+  let j = 1;
+  while (distances[j] < distance && j < distances.length - 1) j++;
+  const k = (times[j] - times[j - 1]) / (distances[j] - distances[j - 1]);
+  const b = times[j] - k * distances[j];
+  const time = k * distance + b;
+  return time;
+};
+
+export const getCsisLevelFromCsis = csis =>
+  Math.min(Math.max(csis, 0), 12).toFixed(0);
+
+const calcLineDis = (dep, dis) => {
+  const theta = dis / EARTH_RADIUS_KM;
+  const a = EARTH_RADIUS_KM - dep;
+  const lineDis = Math.sqrt(
+    a * a +
+      EARTH_RADIUS_KM * EARTH_RADIUS_KM -
+      2 * a * EARTH_RADIUS_KM * Math.cos(theta),
+  );
+  return lineDis;
+};
+
+const calcCeaCsis = (m, dis = 0) =>
+  1.297 * m - 4.368 * Math.log10(dis + 15) + 5.363;
+
+export const calcCsis = (m, dep = 10, dis = 0) => {
+  m = Number(m);
+  dep = Number(dep);
+  dis = Number(dis);
+  if (isNaN(m) || isNaN(dis)) return 0;
+  if (dis > 10000) return 0;
+  dep = isNaN(dep) || dep === null || dep < 10 ? 10 : dep;
+  const lineDis = calcLineDis(dep, dis);
+  const long = 10 ** ((m - 3.821) / 1.86);
+  const hypoDis = Math.max(
+    lineDis - 10 - long,
+    dis - long,
+    0.2 * (lineDis - 10),
+    0,
+  );
+  const ceaCsis1 = calcCeaCsis(m, dis);
+  const ceaCsis2 = calcCeaCsis(m, hypoDis);
+  return (ceaCsis1 + ceaCsis2) / 2;
+};
+
+export const calcCsisLevel = (m, dep = 10, dis = 0) =>
+  getCsisLevelFromCsis(calcCsis(m, dep, dis));
+
+export const getShindoFromInstShindo = (instShindo, useSymbol = true) => {
+  if (instShindo < -3.0) return "?";
+  else if (instShindo < 0.5) return "0";
+  else if (instShindo < 1.5) return "1";
+  else if (instShindo < 2.5) return "2";
+  else if (instShindo < 3.5) return "3";
+  else if (instShindo < 4.5) return "4";
+  else if (instShindo < 5.0) return useSymbol ? "5-" : "5弱";
+  else if (instShindo < 5.5) return useSymbol ? "5+" : "5強";
+  else if (instShindo < 6.0) return useSymbol ? "6-" : "6弱";
+  else if (instShindo < 6.5) return useSymbol ? "6+" : "6強";
+  else return "7";
+};
+
+export const calcJmaShindo = (mj, dep, hypoLat, hypoLng, loc) => {
+  const mw = mj - 0.171;
+  const long = 10 ** (0.5 * mw - 1.85) / 2;
+  const surfaceDist = calcSurfaceDistanceKm(
+    hypoLat,
+    hypoLng,
+    loc.location[0],
+    loc.location[1],
+  );
+  const lineDis = calcLineDis(dep, surfaceDist);
+  const hypoDist = lineDis - long;
+  const x = Math.max(hypoDist, 3);
+  const pgv600 =
+    10 **
+    (0.58 * mw +
+      0.0038 * dep -
+      1.29 -
+      Math.log10(x + 0.0028 * 10 ** (0.5 * mw)) -
+      0.002 * x);
+  const arv = Number(loc.arv);
+  const pgv400 = pgv600 * 1.307;
+  const pgv = pgv400 * arv;
+  const instShindo = 2.68 + 1.72 * Math.log10(pgv);
+  return instShindo;
+};
+
+export const calcJmaShindoLevel = (
+  mj,
+  dep,
+  hypoLat,
+  hypoLng,
+  loc,
+  useSymbol = true,
+) => {
+  const instShindo = calcJmaShindo(mj, dep, hypoLat, hypoLng, loc);
+  const instShindo1 = Math.floor(Math.round(instShindo * 100) / 10) / 10;
+  if (instShindo1 < 0.5) return "0";
+  else return getShindoFromInstShindo(instShindo1, useSymbol);
+};

--- a/src/utils/TopojsonCache.js
+++ b/src/utils/TopojsonCache.js
@@ -1,0 +1,53 @@
+const TOPOJSON_CACHE_NAME = "topojson";
+const JSON_HEADERS = {
+  headers: {
+    "content-type": "application/json",
+  },
+};
+
+const canUseCache = () => typeof window !== "undefined" && "caches" in window;
+
+const cacheResponse = data =>
+  new Response(JSON.stringify(data), JSON_HEADERS);
+
+export const warmTopojsonCache = async (topojsonUrls, fetchJson) => {
+  if (!canUseCache()) return;
+
+  const cache = await caches.open(TOPOJSON_CACHE_NAME);
+  await Promise.all(
+    Object.values(topojsonUrls).map(async url => {
+      const data = await fetchJson(url);
+      if (!data) throw new Error(`empty topojson response: ${url}`);
+      await cache.put(url, cacheResponse(data));
+    }),
+  );
+};
+
+export const loadTopojsonResources = async (topojsonUrls, preferCache) => {
+  const cache = preferCache && canUseCache()
+    ? await caches.open(TOPOJSON_CACHE_NAME)
+    : null;
+
+  return Promise.all(
+    Object.values(topojsonUrls).map(async url => {
+      if (cache) {
+        const cached = await cache.match(url);
+        if (cached) {
+          try {
+            return await cached.json();
+          } catch (err) {
+            console.warn(`invalid cached topojson: ${url}`, err);
+          }
+        }
+      }
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`failed to load topojson ${url}: ${response.status}`);
+      }
+      const data = await response.json();
+      if (cache) await cache.put(url, cacheResponse(data));
+      return data;
+    }),
+  );
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,6 +29,30 @@ export default defineConfig({
     minify: !process.env.TAURI_ENV_DEBUG ? 'esbuild' : false,
     // 在 debug 构建中生成 sourcemap
     sourcemap: !!process.env.TAURI_ENV_DEBUG,
+    cssCodeSplit: true,
+    chunkSizeWarningLimit: 1200,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('/src/utils/CnSeisIntLoc')) return 'geo-cn-seis-int'
+          if (id.includes('/src/utils/JmaSeisIntLoc')) return 'geo-jma-seis-int'
+          if (id.includes('/src/utils/TravelTimes')) return 'travel-times'
+          if (id.includes('/src/utils/FERegions')) return 'fe-regions'
+          if (!id.includes('node_modules')) return
+          if (id.includes('element-plus') || id.includes('@element-plus')) return 'ui-vendor'
+          if (id.includes('leaflet')) return 'map-vendor'
+          if (id.includes('@tauri-apps')) return 'tauri-vendor'
+          if (
+            id.includes('@turf') ||
+            id.includes('topojson') ||
+            id.includes('geokdbush') ||
+            id.includes('kdbush')
+          ) return 'geo-vendor'
+          if (id.includes('vue') || id.includes('pinia')) return 'vue-vendor'
+          return 'vendor'
+        },
+      },
+    },
   },
   plugins: [
     vue(),


### PR DESCRIPTION
# 改动总结-注意PR合并代码审计

## 合并与冲突处理

- 已拉取并合并 `upstream/merge-perf-opt`。
- 已解决 `src/utils/Utils.js` 冲突。
- 保留远端对 `formatShindo` 的增强处理。
- 保留本地前端性能优化拆分，避免大数据表重新进入通用工具模块。

## 前端性能优化

- 拆分 `Utils.js` 中的地震计算逻辑到独立工具文件。
- 新增动态加载的区域距离计算模块。
- 新增 TopoJSON 缓存加载工具。
- 优化 Vite 分包配置，拆分 Vue、地图、Tauri、UI、地理数据等 chunk。
- 修复部分 `visibilitychange` 监听无法清理的问题。
- 字体增加 `font-display: swap`，减少字体加载阻塞。

## 工程化调整

- 增加 `build:profile`、`tauri:dev`、`tauri:build` 脚本。
- CI 中 `pnpm install` 改为 `pnpm install --frozen-lockfile`。

## 验证结果

- `pnpm build` 已通过。
- 本地预览服务可正常访问。
- 首页、JS、CSS、字体、地图 JSON 等资源均返回 `200 OK`。

## 注意事项
- 当前构建中 `geo-cn-seis-int` 又出现在首屏预加载列表中，会削弱部分首屏优化效果。